### PR TITLE
secure nuke_data.sh script from running without any path argument

### DIFF
--- a/wiki/nuke_data.sh
+++ b/wiki/nuke_data.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+set -e
 CURRENT_DIR=$(dirname "$1")
 
 MEDIAWIKI_LOCAL_SETTINGS_PHP=$(realpath $CURRENT_DIR/mediawiki/shared/LocalSettings.php)


### PR DESCRIPTION
The nuke_data script currently doesn't fail on non-zero return code of the `dirname` command.
this can have tragic consequences if the script is executed without passing any path as an argument (can happen by accident easily) - all the variables will become empty
and the final `rm -f` commands are constructed in a way, that they would remove the whole root filesystem in such scenario:

```
rm -rf $MEDIAWIKI_IMAGES/* #would expand to rm -rf /*
...
rm -rf $MARIADB_DATA/* #would expand to rm -rf /*
```